### PR TITLE
Fixes link to blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ I like the following things:
 * Sitting 
 * Football
 
-This is my [blog](www.batmanimal.com)
+This is my [blog](http://www.batmanimal.com)
 
 The end. 
 =======


### PR DESCRIPTION
Adds `http://` to href so that it links to the blog, instead of a subdirectory of github.
